### PR TITLE
Fix unknown expression exception thrown by JQuery

### DIFF
--- a/zen-plus.coffee
+++ b/zen-plus.coffee
@@ -157,7 +157,7 @@ module.exports =
           @restoreRight = true
 
       # Hide Minimap
-      if $('atom-text-editor /deep/ atom-text-editor-minimap').length and not minimap
+      if $('atom-text-editor').find('atom-text-editor-minimap') and not minimap
         atom.commands.dispatch(
           atom.views.getView(atom.workspace),
           'minimap:toggle'
@@ -199,7 +199,7 @@ module.exports =
         @restoreRight = false
 
       # Restore Minimap
-      if @restoreMinimap and $('atom-text-editor /deep/ atom-text-editor-minimap').length isnt 1
+      if @restoreMinimap and $('atom-text-editor').find('atom-text-editor-minimap') is true
         atom.commands.dispatch(
           atom.views.getView(atom.workspace),
           'minimap:toggle'


### PR DESCRIPTION
For some reason JQuery was throwing exception that it couldn't recognize `'atom-text-editor /deep/ atom-text-editor-minimap'` expression so I've changed it to somewhat less or more obvious and exception has gone.